### PR TITLE
グループ追加機能のバリデーション追記

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
-  # validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true
 end


### PR DESCRIPTION
# What
groupモデルにバリデーションを追記した。

# Why
空白のグループ名を登録できないようにするため。