### PR TITLE
自動更新機能のエラー修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -55,7 +55,7 @@ $(function() {
   })
 
   var reloadMessages = function() {
-    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+    if (window.location.href.match(/\/groups\/\d+\/messages/) && $('.message').length !== 0){
       var last_message_id = $('.message').last().data('id');
       $.ajax({
         url: 'api/messages',


### PR DESCRIPTION
# What
メッセージ画面にメッセージが存在しない場合に、リロードのエラーが出たので修正した。
メッセージが存在しない場合リロードを行わない条件を追加した。

# Why
新規グループを作ったあと、書き込みがあるまでエラーが出るのはアプリとして使いにくいから。